### PR TITLE
Add README for VPC module and update README for EC2 module

### DIFF
--- a/terraform/modules/ec2/README.md
+++ b/terraform/modules/ec2/README.md
@@ -1,19 +1,52 @@
 # EC2 Module
 
-This Terraform module creates an EC2 instance in the default VPC, along with an ED25519 key pair for SSH access.
+This Terraform module provisions an EC2 instance in AWS. Key features include:
 
-## Input Variables
+- Securely generates an ED25519 SSH key pair for accessing the instance.
+- Creates a key pair in AWS.
+- Configurable instance attributes such as AMI, instance type, and tags.
 
-- `key_path` (string): Path to save the private key.
-- `key_name` (string): Name for the key pair.
-- `ami` (string): AMI ID for the EC2 instance.
-- `instance_type` (string): Instance type for the EC2 instance.
-- `instance_name` (string): Name for the EC2 instance.
-- `default_tags` (map): Default tags to apply to resources.
-- `region` (string): AWS region to deploy the resources.
+## Features
+
+- Launches an EC2 instance in a specified subnet.
+- Supports attaching an automatically generated SSH key pair.
+- Provides outputs for instance attributes (e.g., public IP, instance ID).
+
+## Inputs
+
+| Name         | Description                                     | Type        | Default | Required |
+|--------------|-------------------------------------------------|-------------|---------|----------|
+| `key_path`   | Path to save the private key locally            | `string`    |         | yes      |
+| `key_name`   | Name for the key pair in AWS                    | `string`    |         | yes      |
+| `ami`        | AMI ID for the EC2 instance                    | `string`    |         | yes      |
+| `instance_type` | Instance type for the EC2 instance           | `string`    |         | yes      |
+| `instance_name` | Name for the EC2 instance                    | `string`    |         | yes      |
+| `default_tags` | A map of default tags to assign to the instance| `map(string)`| `{}`   | no       |
+| `subnet_id`  | Subnet ID where the EC2 instance will be launched| `string`    |         | yes      |
 
 ## Outputs
 
-- `private_key_path`: Path to the private key file for SSH access.
-- `instance_public_ip`: Public IP address of the EC2 instance.
-- `instance_id`: ID of the EC2 instance.
+| Name                 | Description                                |
+|----------------------|--------------------------------------------|
+| `private_key_path`   | Path to the saved private key              |
+| `instance_public_ip` | Public IP address of the EC2 instance      |
+| `instance_id`        | ID of the EC2 instance                     |
+
+## Example Usage
+
+```hcl
+module "ec2" {
+  source         = "../modules/ec2"
+  key_name       = "personalized-greetings-key"
+  key_path       = "${path.root}/../personalized-greetings-key.pem"
+  ami            = "ami-0866a3c8686eaeeba"
+  instance_type  = "t2.micro"
+  instance_name  = "Personalized-Greetings-EC2"
+  default_tags = {
+    Environment = "Dev"
+    Project     = "Personalized-Greetings"
+  }
+
+  # Specify the subnet for the EC2 instance
+  subnet_id = element(module.vpc.public_subnet_ids, 0)
+}

--- a/terraform/modules/ec2/ec2.tf
+++ b/terraform/modules/ec2/ec2.tf
@@ -22,6 +22,7 @@ resource "aws_key_pair" "generated_key" {
 resource "aws_instance" "ec2_instance" {
   ami           = var.ami
   instance_type = var.instance_type
+  subnet_id     = var.subnet_id  # Specify the subnet for the EC2 instance
 
   key_name = aws_key_pair.generated_key.key_name
 

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -30,4 +30,8 @@ variable "default_tags" {
   type        = map(string)
 }
 
+variable "subnet_id" {
+  description = "The ID of the subnet where the EC2 instance will be launched"
+  type        = string
+}
 

--- a/terraform/modules/vpc/README.md
+++ b/terraform/modules/vpc/README.md
@@ -1,0 +1,48 @@
+# VPC Module
+
+This Terraform module creates a custom Virtual Private Cloud (VPC) infrastructure in AWS, including:
+
+- A VPC with a specified CIDR block.
+- Public and private subnets.
+- An Internet Gateway for public subnet connectivity.
+- Route tables for public and private subnets.
+
+## Features
+
+- Dynamically creates subnets based on provided CIDR blocks.
+- Associates public subnets with a route table for Internet Gateway access.
+- Provides outputs for integrating with other modules, such as EC2.
+
+## Inputs
+
+| Name                  | Description                                     | Type        | Default | Required |
+|-----------------------|-------------------------------------------------|-------------|---------|----------|
+| `cidr_block`          | CIDR block for the VPC                         | `string`    |         | yes      |
+| `vpc_name`            | Name for the VPC                               | `string`    |         | yes      |
+| `public_subnet_cidrs` | List of CIDR blocks for public subnets          | `list`      |         | yes      |
+| `private_subnet_cidrs`| List of CIDR blocks for private subnets         | `list`      |         | yes      |
+| `default_tags`        | A map of default tags to assign to all resources| `map(string)`| `{}`   | no       |
+
+## Outputs
+
+| Name                   | Description                                |
+|------------------------|--------------------------------------------|
+| `vpc_id`               | ID of the created VPC                     |
+| `public_subnet_ids`    | IDs of the created public subnets          |
+| `private_subnet_ids`   | IDs of the created private subnets         |
+| `internet_gateway_id`  | ID of the created Internet Gateway         |
+
+## Example Usage
+
+```hcl
+module "vpc" {
+  source               = "../modules/vpc"
+  cidr_block           = "10.0.0.0/16"
+  vpc_name             = "Personalized-Greetings-VPC"
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnet_cidrs = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+  default_tags = {
+    Environment = "Dev"
+    Project     = "Personalized-Greetings"
+  }
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,21 @@
+# File: ./modules/vpc/outputs.tf
+
+output "vpc_id" {
+  value       = aws_vpc.main.id
+  description = "ID of the created VPC"
+}
+
+output "public_subnet_ids" {
+  value       = aws_subnet.public_subnets.*.id
+  description = "IDs of the public subnets"
+}
+
+output "private_subnet_ids" {
+  value       = aws_subnet.private_subnets.*.id
+  description = "IDs of the private subnets"
+}
+
+output "internet_gateway_id" {
+  value       = aws_internet_gateway.main.id
+  description = "ID of the Internet Gateway"
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,26 @@
+# File: ./modules/vpc/variables.tf
+
+variable "cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "vpc_name" {
+  description = "Name of the VPC"
+  type        = string
+}
+
+variable "public_subnet_cidrs" {
+  description = "List of CIDR blocks for public subnets"
+  type        = list(string)
+}
+
+variable "private_subnet_cidrs" {
+  description = "List of CIDR blocks for private subnets"
+  type        = list(string)
+}
+
+variable "default_tags" {
+  description = "A map of default tags to assign to resources"
+  type        = map(string)
+}

--- a/terraform/modules/vpc/vpc.tf
+++ b/terraform/modules/vpc/vpc.tf
@@ -1,0 +1,66 @@
+# File: ./modules/vpc/vpc.tf
+
+# Create a VPC
+resource "aws_vpc" "main" {
+  cidr_block = var.cidr_block
+  tags       = merge(var.default_tags, { Name = var.vpc_name })
+}
+
+# Create Public Subnets
+resource "aws_subnet" "public_subnets" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.default_tags, { Name = "Public-Subnet-${count.index + 1}" })
+}
+
+# Create Private Subnets
+resource "aws_subnet" "private_subnets" {
+  count      = length(var.private_subnet_cidrs)
+  vpc_id     = aws_vpc.main.id
+  cidr_block = var.private_subnet_cidrs[count.index]
+
+  tags = merge(var.default_tags, { Name = "Private-Subnet-${count.index + 1}" })
+}
+
+# Create an Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags   = merge(var.default_tags, { Name = "Main-Internet-Gateway" })
+}
+
+# Create a Route Table for Public Subnets
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = merge(var.default_tags, { Name = "Public-Route-Table" })
+}
+
+# Associate Public Route Table with Public Subnets
+resource "aws_route_table_association" "public_associations" {
+  count          = length(var.public_subnet_cidrs)
+  subnet_id      = aws_subnet.public_subnets[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# Create a Route Table for Private Subnets (optional)
+# Explanation: Private subnets don't need explicit internet routes in many cases.
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.default_tags, { Name = "Private-Route-Table" })
+}
+
+# Associate Private Route Table with Private Subnets
+resource "aws_route_table_association" "private_associations" {
+  count          = length(var.private_subnet_cidrs)
+  subnet_id      = aws_subnet.private_subnets[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/terraform/personalized_greetings/main.tf
+++ b/terraform/personalized_greetings/main.tf
@@ -21,4 +21,21 @@ module "ec2" {
     Environment = "Dev"
     Project     = "Personalized-Greetings"
   }
+  
+  # Place EC2 in the first public subnet
+  subnet_id = element(module.vpc.public_subnet_ids, 0)
+}
+
+
+
+module "vpc" {
+  source               = "../modules/vpc"
+  cidr_block           = "10.0.0.0/16"
+  vpc_name             = "Personalized-Greetings-VPC"
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnet_cidrs = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+  default_tags = {
+    Environment = "Dev"
+    Project     = "Personalized-Greetings"
+  }
 }


### PR DESCRIPTION
- Added detailed README for the VPC module:
  - Describes inputs, outputs, and example usage.
  - Highlights features such as public and private subnet creation, route tables, and Internet Gateway configuration.

- Updated README for EC2 module:
  - Includes the new 'subnet_id' input variable for integrating with the VPC module.
  - Provides a detailed example usage with the VPC.

- Ensured consistency in documentation for easier usage and integration.